### PR TITLE
docs: add per-package API reference under doc/

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ go get github.com/labacacia/nps/impl/go@v1.0.0-alpha.1
 
 ## Packages
 
-| Import path | Description |
-|-------------|-------------|
-| `.../impl/go/core` | Frame header, codec (Tier-1 JSON / Tier-2 MsgPack), registry, anchor cache, errors |
-| `.../impl/go/ncp`  | NCP frames: `AnchorFrame`, `DiffFrame`, `StreamFrame`, `CapsFrame`, `ErrorFrame`, `HelloFrame` |
-| `.../impl/go/nwp`  | NWP frames: `QueryFrame`, `ActionFrame`; HTTP `Client` |
-| `.../impl/go/nip`  | NIP frames: `IdentFrame`, `TrustFrame`, `RevokeFrame`; Ed25519 `Identity` |
-| `.../impl/go/ndp`  | NDP frames: `AnnounceFrame`, `ResolveFrame`, `GraphFrame`; registry & validator |
-| `.../impl/go/nop`  | NOP frames: `TaskFrame`, `DelegateFrame`, `SyncFrame`, `AlignStreamFrame`; DAG models and client |
+| Import path | Description | Reference |
+|-------------|-------------|-----------|
+| `.../impl/go/core` | Frame header, codec (Tier-1 JSON / Tier-2 MsgPack), registry, anchor cache, errors | [`doc/nps-go.core.md`](./doc/nps-go.core.md) |
+| `.../impl/go/ncp`  | NCP frames: `AnchorFrame`, `DiffFrame`, `StreamFrame`, `CapsFrame`, `ErrorFrame` | [`doc/nps-go.ncp.md`](./doc/nps-go.ncp.md) |
+| `.../impl/go/nwp`  | NWP frames: `QueryFrame`, `ActionFrame`; HTTP `NwpClient` | [`doc/nps-go.nwp.md`](./doc/nps-go.nwp.md) |
+| `.../impl/go/nip`  | NIP frames: `IdentFrame`, `TrustFrame`, `RevokeFrame`; Ed25519 `NipIdentity` | [`doc/nps-go.nip.md`](./doc/nps-go.nip.md) |
+| `.../impl/go/ndp`  | NDP frames: `AnnounceFrame`, `ResolveFrame`, `GraphFrame`; `InMemoryNdpRegistry` + `NdpAnnounceValidator` | [`doc/nps-go.ndp.md`](./doc/nps-go.ndp.md) |
+| `.../impl/go/nop`  | NOP frames: `TaskFrame`, `DelegateFrame`, `SyncFrame`, `AlignStreamFrame`; `BackoffStrategy` + `NopTaskStatus` + `NopClient` | [`doc/nps-go.nop.md`](./doc/nps-go.nop.md) |
+
+Full API reference lives under [`doc/`](./doc/) — start with [`doc/overview.md`](./doc/overview.md). For a narrative walkthrough see [`doc/sdk-usage.md`](./doc/sdk-usage.md) / [`doc/sdk-usage.cn.md`](./doc/sdk-usage.cn.md).
 
 ## Quick Start
 

--- a/doc/nps-go.core.md
+++ b/doc/nps-go.core.md
@@ -1,0 +1,244 @@
+# `github.com/labacacia/nps/impl/go/core` — Reference
+
+> Spec: [NPS-1 NCP v0.4](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-1-NCP.md)
+
+Foundation package — wire header, encoding tiers, registry-validated
+codec, anchor cache, typed errors.
+
+---
+
+## Table of contents
+
+- [`FrameType`](#frametype)
+- [`EncodingTier`](#encodingtier)
+- [`FrameHeader`](#frameheader)
+- [`FrameDict`](#framedict)
+- [`NpsFrameCodec`](#npsframecodec)
+- [`FrameRegistry`](#frameregistry)
+- [`AnchorFrameCache`](#anchorframecache)
+- [Error types](#error-types)
+
+---
+
+## `FrameType`
+
+```go
+type FrameType uint8
+
+const (
+    FrameTypeAnchor      FrameType = 0x01
+    FrameTypeDiff        FrameType = 0x02
+    FrameTypeStream      FrameType = 0x03
+    FrameTypeCaps        FrameType = 0x04
+    FrameTypeQuery       FrameType = 0x10
+    FrameTypeAction      FrameType = 0x11
+    FrameTypeIdent       FrameType = 0x20
+    FrameTypeTrust       FrameType = 0x21
+    FrameTypeRevoke      FrameType = 0x22
+    FrameTypeAnnounce    FrameType = 0x30
+    FrameTypeResolve     FrameType = 0x31
+    FrameTypeGraph       FrameType = 0x32
+    FrameTypeTask        FrameType = 0x40
+    FrameTypeDelegate    FrameType = 0x41
+    FrameTypeSync        FrameType = 0x42
+    FrameTypeAlignStream FrameType = 0x43
+    FrameTypeError       FrameType = 0xFE
+)
+
+func FrameTypeFromByte(b byte) (FrameType, error)   // error on unknown
+```
+
+---
+
+## `EncodingTier`
+
+```go
+type EncodingTier uint8
+
+const (
+    EncodingTierJSON    EncodingTier = 0
+    EncodingTierMsgPack EncodingTier = 1
+)
+```
+
+The value is the bit-7 state of the flags byte.
+
+---
+
+## `FrameHeader`
+
+```go
+type FrameHeader struct {
+    FrameType     FrameType
+    Flags         uint8
+    PayloadLength uint64
+    IsExtended    bool
+}
+
+func NewFrameHeader(ft FrameType, tier EncodingTier,
+                    isFinal bool, payloadLen uint64) FrameHeader
+
+func (h FrameHeader) EncodingTier() EncodingTier   // bit 7
+func (h FrameHeader) IsFinal() bool                // bit 6
+func (h FrameHeader) HeaderSize() int              // 4 or 8
+func (h FrameHeader) ToBytes() []byte
+
+func ParseFrameHeader(wire []byte) (FrameHeader, error)
+```
+
+### Flags byte
+
+| Bit | Mask   | Meaning |
+|-----|--------|---------|
+| 7   | `0x80` | TIER — `1` = MsgPack, `0` = JSON |
+| 6   | `0x40` | FINAL — last frame in a stream |
+| 0   | `0x01` | EXT — 8-byte extended header |
+
+### Wire layout
+
+```
+Default (EXT=0, 4 bytes):
+  [frame_type][flags][len_hi][len_lo]           — u16 big-endian length
+
+Extended (EXT=1, 8 bytes):
+  [frame_type][flags][0][0][len_b3..len_b0]     — u32 big-endian length
+```
+
+`NewFrameHeader` auto-enables EXT when `payloadLen > 0xFFFF`.
+
+---
+
+## `FrameDict`
+
+```go
+type FrameDict = map[string]any
+```
+
+Every frame type round-trips through `FrameDict`. The underlying map
+carries whatever the codec pulled out of JSON / MsgPack — typical
+value types are `string`, `bool`, `float64`, `int64`, `uint64`,
+`[]any`, `map[string]any`. Frame-specific helpers (in the protocol
+packages) normalise these into typed fields.
+
+---
+
+## `NpsFrameCodec`
+
+```go
+const DefaultMaxPayload = 10 * 1024 * 1024   // 10 MiB
+
+type NpsFrameCodec struct {
+    Registry   *FrameRegistry
+    MaxPayload int64
+}
+
+func NewNpsFrameCodec(reg *FrameRegistry) *NpsFrameCodec
+
+func (c *NpsFrameCodec) Encode(
+    ft       FrameType,
+    dict     FrameDict,
+    tier     EncodingTier,
+    isFinal  bool,
+) ([]byte, error)
+
+func (c *NpsFrameCodec) Decode(wire []byte) (FrameType, FrameDict, error)
+
+func PeekHeader(wire []byte) (FrameHeader, error)
+```
+
+- `Encode` fails with `*ErrCodec` if the serialised payload exceeds
+  `c.MaxPayload`.
+- `Decode` fails with `*ErrFrame` if the header's frame type is not
+  registered against this codec's `FrameRegistry`.
+- `PeekHeader` is a package-level function (no receiver) — call it
+  before allocating to know the full frame length.
+
+Adjust the payload cap by setting `codec.MaxPayload = …` directly on
+the instance.
+
+---
+
+## `FrameRegistry`
+
+```go
+type FrameRegistry struct { /* … */ }
+
+func NewFrameRegistry() *FrameRegistry                      // empty
+func (r *FrameRegistry) Register(ft FrameType)
+func (r *FrameRegistry) IsRegistered(ft FrameType) bool
+
+func CreateDefaultRegistry() *FrameRegistry                 // NCP only
+func CreateFullRegistry()    *FrameRegistry                 // NCP+NWP+NIP+NDP+NOP
+```
+
+`CreateDefaultRegistry` covers only the NCP frames
+(`Anchor / Diff / Stream / Caps / Error`). Use `CreateFullRegistry`
+when decoding NWP / NIP / NDP / NOP payloads or when routing a
+response that may carry any frame type.
+
+---
+
+## `AnchorFrameCache`
+
+Thread-safe anchor-schema cache with lazy TTL expiry. Uses an internal
+`sync.RWMutex`; a single instance is safe for concurrent use.
+
+```go
+type AnchorFrameCache struct {
+    Clock func() time.Time   // injectable; default time.Now
+    // internal fields …
+}
+
+func NewAnchorFrameCache() *AnchorFrameCache
+
+// SHA-256 hex of canonical (sorted-key) JSON, prefixed "sha256:".
+func ComputeAnchorID(schema FrameDict) string
+
+func (c *AnchorFrameCache) Set(schema FrameDict, ttlSecs int64) (string, error)
+func (c *AnchorFrameCache) Get(id string) FrameDict                       // nil if missing/expired
+func (c *AnchorFrameCache) GetRequired(id string) (FrameDict, error)
+func (c *AnchorFrameCache) Invalidate(id string)
+func (c *AnchorFrameCache) Len() int                                      // live count only
+```
+
+### Poisoning
+
+`Set` returns `*ErrAnchorPoison` when the same `anchor_id` is already
+cached with a **different** schema and still live. Re-inserts with an
+identical schema simply refresh the TTL.
+
+### Lazy expiry
+
+`Get` / `GetRequired` / `Len` filter by `expires > clock()` without
+mutating the store. There is no explicit `EvictExpired()` — expired
+entries are overwritten on next `Set`.
+
+### Injectable clock
+
+```go
+fake := time.Unix(1_700_000_000, 0)
+cache := core.NewAnchorFrameCache()
+cache.Clock = func() time.Time { return fake }
+```
+
+---
+
+## Error types
+
+```go
+type ErrFrame          struct{ Msg string }
+type ErrCodec          struct{ Msg string }
+type ErrAnchorNotFound struct{ ID  string }
+type ErrAnchorPoison   struct{ ID  string }
+type ErrIdentity       struct{ Msg string }
+```
+
+All five implement `error` via a pointer receiver. Use `errors.As` to
+discriminate:
+
+```go
+var notFound *core.ErrAnchorNotFound
+if errors.As(err, &notFound) {
+    log.Printf("missing anchor: %s", notFound.ID)
+}
+```

--- a/doc/nps-go.ncp.md
+++ b/doc/nps-go.ncp.md
@@ -1,0 +1,175 @@
+# `github.com/labacacia/nps/impl/go/ncp` — Reference
+
+> Spec: [NPS-1 NCP v0.4](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-1-NCP.md)
+
+The five NCP frame types. Every struct exposes the same trio:
+
+```go
+func (f *XxxFrame) FrameType() core.FrameType
+func (f *XxxFrame) ToDict()    core.FrameDict
+func XxxFrameFromDict(d core.FrameDict) *XxxFrame
+```
+
+> **Note — Go frame shapes.** The Go NCP structs carry a slightly different
+> field set from the Java / Python / .NET / TS SDKs — the layouts below are
+> authoritative for this module.
+
+---
+
+## Table of contents
+
+- [`AnchorFrame` (0x01)](#anchorframe-0x01)
+- [`DiffFrame` (0x02)](#diffframe-0x02)
+- [`StreamFrame` (0x03)](#streamframe-0x03)
+- [`CapsFrame` (0x04)](#capsframe-0x04)
+- [`ErrorFrame` (0xFE)](#errorframe-0xfe)
+
+---
+
+## `AnchorFrame` (0x01)
+
+Publishes a schema anchor + TTL.
+
+```go
+type AnchorFrame struct {
+    AnchorID    string
+    Schema      core.FrameDict
+    Namespace   *string
+    Description *string
+    NodeType    *string          // e.g. "memory" | "action" | …
+    TTL         uint64           // seconds; from_dict defaults to 3600
+}
+```
+
+`Schema` is stored as a free-form `core.FrameDict` — typically
+`{"fields": [ {"name": …, "type": …}, … ]}` but any shape your nodes and
+clients agree on is valid. `AnchorFrameFromDict` falls back to `TTL = 3600`
+when the field is missing / zero.
+
+To produce the content-addressed `AnchorID` deterministically use
+[`core.ComputeAnchorID`](./nps-go.core.md#anchorframecache).
+
+---
+
+## `DiffFrame` (0x02)
+
+Schema evolution between two anchors.
+
+```go
+type DiffFrame struct {
+    AnchorID    string        // old anchor
+    NewAnchorID string        // new anchor
+    Patch       []any         // JSON-Patch-shaped ops (free-form)
+}
+```
+
+`Patch` is serialized verbatim — this module does not validate the ops; the
+receiver is expected to know the patch dialect (NPS-1 §5.2 uses
+RFC 6902-compatible shape).
+
+---
+
+## `StreamFrame` (0x03)
+
+One chunk of a streamed response. Multiple `StreamFrame`s tile out a
+result; the final chunk sets `IsLast = true`.
+
+```go
+type StreamFrame struct {
+    AnchorID string
+    Seq      uint64
+    Payload  any        // opaque — any JSON-representable value
+    IsLast   bool
+}
+```
+
+The wire-level `FINAL` flag (bit 6 of the header) is **separate** from
+`IsLast`. `IsLast` is an in-payload business marker used by
+[`NwpClient.Stream`](./nps-go.nwp.md#nwpclient) to stop iterating.
+
+---
+
+## `CapsFrame` (0x04)
+
+Node capability / response-envelope frame.
+
+```go
+type CapsFrame struct {
+    NodeID    string
+    Caps      []string          // capability URIs
+    AnchorRef *string           // anchor being answered against
+    Payload   any               // opaque response data
+}
+```
+
+In the Go SDK `CapsFrame` is the **default response envelope** for NWP:
+`NwpClient.Query` returns a `*CapsFrame` directly (it reads `AnchorRef` +
+`Payload`). Caps-advertisement usage and response usage share the same
+struct — differentiate by inspecting `Caps` vs `Payload`.
+
+`CapsFrameFromDict` accepts either `[]string` or `[]any` for the `caps`
+field — MsgPack-decoded payloads typically surface as `[]any`, JSON
+payloads as `[]any` of strings; both are normalised to `[]string`.
+
+---
+
+## `ErrorFrame` (0xFE)
+
+Unified protocol-level error.
+
+```go
+type ErrorFrame struct {
+    ErrorCode string        // "NWP-QUERY-ANCHOR-UNKNOWN", …
+    Message   string
+    Detail    any           // free-form extra context
+}
+```
+
+See [`error-codes.md`](https://github.com/labacacia/NPS-Release/blob/main/spec/error-codes.md)
+for the namespace.
+
+---
+
+## End-to-end
+
+```go
+import (
+    "github.com/labacacia/nps/impl/go/core"
+    "github.com/labacacia/nps/impl/go/ncp"
+)
+
+codec := core.NewNpsFrameCodec(core.CreateDefaultRegistry())
+
+schema := core.FrameDict{
+    "fields": []any{
+        map[string]any{"name": "id", "type": "uint64"},
+    },
+}
+namespace  := "example.products"
+description := "product catalog v1"
+nodeType   := "memory"
+
+frame := &ncp.AnchorFrame{
+    AnchorID:    core.ComputeAnchorID(schema),
+    Schema:      schema,
+    Namespace:   &namespace,
+    Description: &description,
+    NodeType:    &nodeType,
+    TTL:         3600,
+}
+
+wire, err := codec.Encode(
+    frame.FrameType(),
+    frame.ToDict(),
+    core.EncodingTierMsgPack,
+    true, // isFinal
+)
+if err != nil { /* … */ }
+
+ft, dict, err := codec.Decode(wire)
+if err != nil { /* … */ }
+if ft == core.FrameTypeAnchor {
+    back := ncp.AnchorFrameFromDict(dict)
+    _ = back.TTL   // 3600
+}
+```

--- a/doc/nps-go.ndp.md
+++ b/doc/nps-go.ndp.md
@@ -1,0 +1,253 @@
+# `github.com/labacacia/nps/impl/go/ndp` — Reference
+
+> Spec: [NPS-4 NDP v0.2](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-4-NDP.md)
+
+Discovery layer — the NPS analogue of DNS. Three frames, an in-memory TTL
+registry, and a signature validator.
+
+---
+
+## Table of contents
+
+- [`AnnounceFrame` (0x30)](#announceframe-0x30)
+- [`ResolveFrame` (0x31)](#resolveframe-0x31)
+- [`GraphFrame` (0x32)](#graphframe-0x32)
+- [`InMemoryNdpRegistry`](#inmemoryndpregistry)
+- [`ResolveResult`](#resolveresult)
+- [`NdpAnnounceValidator`](#ndpannouncevalidator)
+- [`NdpAnnounceResult`](#ndpannounceresult)
+
+---
+
+## `AnnounceFrame` (0x30)
+
+Publishes a node's physical reachability and TTL (NPS-4 §3.1).
+
+```go
+type AnnounceFrame struct {
+    NID       string
+    Addresses []map[string]any       // [{"host","port","protocol"}, …]
+    Caps      []string
+    TTL       uint64                 // seconds; 0 = shutdown
+    Timestamp string                 // ISO 8601 UTC
+    Signature string                 // "ed25519:{base64}"
+    NodeType  *string
+}
+
+func (f *AnnounceFrame) UnsignedDict() core.FrameDict   // canonical (sorted) + signature stripped
+func (f *AnnounceFrame) ToDict()       core.FrameDict
+func AnnounceFrameFromDict(d core.FrameDict) *AnnounceFrame
+```
+
+`UnsignedDict()` returns a sorted dict (keys inserted in lexical order),
+so signing via `nip.NipIdentity.Sign` is a single call — the canonical
+JSON and the dict you sign share the same key order. `AnnounceFrameFromDict`
+defaults `TTL` to `300` when absent / zero.
+
+Publishing `TTL = 0` SHOULD precede a graceful shutdown so subscribers
+evict the entry promptly.
+
+---
+
+## `ResolveFrame` (0x31)
+
+Request / response envelope for resolving an `nwp://` URL.
+
+```go
+type ResolveFrame struct {
+    Target       string             // "nwp://..."
+    RequesterNID *string
+    Resolved     map[string]any     // set on response
+}
+```
+
+---
+
+## `GraphFrame` (0x32)
+
+Topology sync between registries.
+
+```go
+type GraphFrame struct {
+    Seq         uint64             // strictly monotonic per publisher
+    InitialSync bool                // full snapshot flag
+    Nodes       []any               // full dump when InitialSync = true
+    Patch       []any               // RFC 6902 ops for incremental sync
+}
+```
+
+Gaps in `Seq` trigger a re-sync request signalled with
+`NDP-GRAPH-SEQ-GAP` (see
+[`error-codes.md`](https://github.com/labacacia/NPS-Release/blob/main/spec/error-codes.md)).
+
+---
+
+## `InMemoryNdpRegistry`
+
+In-memory, concurrency-safe registry with TTL expiry evaluated **lazily**
+on every read. Uses an internal `sync.RWMutex`; a single instance is safe
+for concurrent use.
+
+```go
+type InMemoryNdpRegistry struct {
+    Clock func() time.Time          // injectable; default time.Now
+    // internal fields …
+}
+
+func NewInMemoryNdpRegistry() *InMemoryNdpRegistry
+
+func (r *InMemoryNdpRegistry) Announce  (frame *AnnounceFrame)
+func (r *InMemoryNdpRegistry) GetByNID  (nid string)      *AnnounceFrame   // nil if missing/expired
+func (r *InMemoryNdpRegistry) Resolve   (target string)   *ResolveResult   // nil if unresolved
+func (r *InMemoryNdpRegistry) GetAll    ()                []*AnnounceFrame // live entries only
+
+// Package-level helper.
+func NwpTargetMatchesNID(nid, target string) bool
+```
+
+### Behaviour
+
+- `Announce` with `TTL == 0` evicts the NID immediately. Otherwise the
+  entry is stored with an absolute expiry of `Clock() + TTL seconds` —
+  subsequent announces refresh the entry in place.
+- `GetByNID` / `Resolve` / `GetAll` skip expired entries without mutating
+  the store.
+- `Resolve` scans live entries, finds the **first** NID that covers
+  `target`, and returns its **first** advertised address as a
+  `*ResolveResult`.
+
+### `NwpTargetMatchesNID(nid, target)`
+
+Covering rule — free-standing package-level helper:
+
+```
+NID:    urn:nps:node:{authority}:{path}
+Target: nwp://{authority}/{path}[/sub/path]
+```
+
+A node NID covers a target when:
+
+1. `target` starts with `"nwp://"`.
+2. The NID authority equals the target authority (exact,
+   case-sensitive).
+3. The target path equals `{path}` exactly, or starts with `{path}/`
+   (sibling prefixes like `"data"` vs `"dataset"` do **not** match).
+
+Returns `false` on malformed inputs — never panics.
+
+### Injectable clock
+
+```go
+fake := time.Unix(1_700_000_000, 0)
+registry := ndp.NewInMemoryNdpRegistry()
+registry.Clock = func() time.Time { return fake }
+```
+
+---
+
+## `ResolveResult`
+
+```go
+type ResolveResult struct {
+    Host     string
+    Port     uint64
+    Protocol string
+}
+```
+
+Fields are extracted directly from the first `map[string]any` in
+`AnnounceFrame.Addresses` — missing / typed-mismatched values surface as
+zero (`""`, `0`) rather than defaults.
+
+---
+
+## `NdpAnnounceValidator`
+
+Verifies an `AnnounceFrame.Signature` against a registered Ed25519 public
+key. Uses an internal `sync.RWMutex`; a single instance is safe for
+concurrent use.
+
+```go
+type NdpAnnounceValidator struct { /* … */ }
+
+func NewNdpAnnounceValidator() *NdpAnnounceValidator
+
+func (v *NdpAnnounceValidator) RegisterPublicKey(nid, pubKey string)
+func (v *NdpAnnounceValidator) RemovePublicKey  (nid string)
+func (v *NdpAnnounceValidator) KnownPublicKeys  () map[string]string   // snapshot copy
+
+func (v *NdpAnnounceValidator) Validate(frame *AnnounceFrame) NdpAnnounceResult
+```
+
+Validation sequence (NPS-4 §7.1):
+
+1. Look up `frame.NID` in the registered keys. Missing →
+   `NdpAnnounceResult{IsValid:false, ErrorCode:"NDP-ANNOUNCE-NID-MISMATCH"}`.
+   Expected workflow: verify the announcer's `IdentFrame` first, then
+   `RegisterPublicKey(nid, ident.PubKey)`.
+2. `Signature` MUST start with `"ed25519:"`, else
+   `NDP-ANNOUNCE-SIG-INVALID`.
+3. Rebuild the signing payload from `frame.UnsignedDict()` (already
+   sorted) and call
+   [`nip.VerifyWithPubKeyStr`](./nps-go.nip.md#nipidentity).
+4. Return `NdpAnnounceResult{IsValid:true}` on success, else
+   `NDP-ANNOUNCE-SIG-INVALID`.
+
+Register keys using the exact string produced by
+`NipIdentity.PubKeyString()` — i.e. `"ed25519:{hex}"`.
+
+---
+
+## `NdpAnnounceResult`
+
+```go
+type NdpAnnounceResult struct {
+    IsValid   bool
+    ErrorCode string       // "" when IsValid
+    Message   string
+}
+```
+
+---
+
+## End-to-end
+
+```go
+import (
+    "time"
+    "github.com/labacacia/nps/impl/go/ndp"
+    "github.com/labacacia/nps/impl/go/nip"
+)
+
+id, _ := nip.Generate()
+nid   := "urn:nps:node:api.example.com:products"
+
+// Build + sign the announce
+nodeType := "memory"
+unsigned := &ndp.AnnounceFrame{
+    NID: nid,
+    Addresses: []map[string]any{
+        {"host": "10.0.0.5", "port": uint64(17433), "protocol": "nwp+tls"},
+    },
+    Caps:      []string{"nwp:query", "nwp:stream"},
+    TTL:       300,
+    Timestamp: time.Now().UTC().Format(time.RFC3339),
+    NodeType:  &nodeType,
+}
+unsigned.Signature = id.Sign(unsigned.UnsignedDict())
+
+// Validate + register
+validator := ndp.NewNdpAnnounceValidator()
+validator.RegisterPublicKey(nid, id.PubKeyString())
+result := validator.Validate(unsigned)
+_ = result.IsValid   // true
+
+// Resolve
+registry := ndp.NewInMemoryNdpRegistry()
+registry.Announce(unsigned)
+resolved := registry.Resolve("nwp://api.example.com/products/items/42")
+if resolved != nil {
+    _ = resolved.Host    // "10.0.0.5"
+    _ = resolved.Port    // 17433
+}
+```

--- a/doc/nps-go.nip.md
+++ b/doc/nps-go.nip.md
@@ -1,0 +1,187 @@
+# `github.com/labacacia/nps/impl/go/nip` — Reference
+
+> Spec: [NPS-3 NIP v0.2](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-3-NIP.md)
+
+Identity layer. Three frames + an Ed25519 helper with
+AES-256-GCM-encrypted on-disk persistence.
+
+---
+
+## Table of contents
+
+- [`IdentFrame` (0x20)](#identframe-0x20)
+- [`TrustFrame` (0x21)](#trustframe-0x21)
+- [`RevokeFrame` (0x22)](#revokeframe-0x22)
+- [`NipIdentity`](#nipidentity)
+- [Key file format](#key-file-format)
+
+---
+
+## `IdentFrame` (0x20)
+
+Node identity declaration.
+
+```go
+type IdentFrame struct {
+    NID       string                // "urn:nps:node:{authority}:{name}"
+    PubKey    string                // "ed25519:{hex}"
+    Meta      map[string]any
+    Signature *string               // "ed25519:{base64}"
+}
+
+func (f *IdentFrame) UnsignedDict() core.FrameDict    // strips `signature`
+func (f *IdentFrame) ToDict()       core.FrameDict
+func IdentFrameFromDict(d core.FrameDict) *IdentFrame
+```
+
+Signing workflow:
+
+1. Construct with `Signature: nil`.
+2. `sig := id.Sign(frame.UnsignedDict())` → `"ed25519:{base64}"`.
+3. Assign `frame.Signature = &sig` before encoding.
+
+---
+
+## `TrustFrame` (0x21)
+
+Delegation / trust assertion.
+
+```go
+type TrustFrame struct {
+    IssuerNID  string
+    SubjectNID string
+    Scopes     []string
+    ExpiresAt  *string            // ISO 8601 UTC
+    Signature  *string            // "ed25519:{base64}"
+}
+```
+
+Same signing convention: canonical-JSON of the dict minus the `signature`
+field. `TrustFrameFromDict` accepts either `[]string` or `[]any` for the
+`scopes` field (MsgPack decoders typically emit `[]any`).
+
+---
+
+## `RevokeFrame` (0x22)
+
+Revokes an NID — precede or accompany an `AnnounceFrame` with `TTL == 0`.
+
+```go
+type RevokeFrame struct {
+    NID       string
+    Reason    *string
+    RevokedAt *string
+}
+```
+
+---
+
+## `NipIdentity`
+
+Ed25519 keypair plus canonical-JSON sign / verify.
+
+```go
+type NipIdentity struct { /* … */ }
+
+func Generate() (*NipIdentity, error)
+
+func (id *NipIdentity) PubKeyString() string                          // "ed25519:{hex}"
+
+func (id *NipIdentity) Sign  (payload core.FrameDict) string          // "ed25519:{base64}"
+func (id *NipIdentity) Verify(payload core.FrameDict, signature string) bool
+
+// Package-level helper: parse an "ed25519:{hex}" public key string and
+// verify against `payload`.
+func VerifyWithPubKeyStr(payload core.FrameDict, pubKey, signature string) bool
+
+func (id *NipIdentity) Save(path, passphrase string) error
+func Load(path, passphrase string) (*NipIdentity, error)
+```
+
+### Canonical signing payload
+
+Both `Sign` and `Verify` serialise the payload by sorting keys
+lexicographically and marshalling through `encoding/json` — no
+whitespace, lexical key order. This matches the sorted-keys canonicaliser
+shared with the .NET / Python / Java / TS / Rust SDKs;
+**RFC 8785 JCS is NOT used**.
+
+### Verification
+
+- `Verify(payload, sig)` verifies against the instance's own public key.
+- `VerifyWithPubKeyStr` is the free-standing helper used by
+  [`NdpAnnounceValidator`](./nps-go.ndp.md#ndpannouncevalidator) — it
+  parses `"ed25519:{hex}"` → 32-byte public key → verifies via
+  `crypto/ed25519`.
+
+Both verifiers return `false` on any parsing, length, or signature
+mismatch error — they never panic.
+
+---
+
+## Key file format
+
+`Save` writes an encrypted JSON envelope (mode `0600`):
+
+```json
+{
+  "version":    1,
+  "algorithm":  "ed25519",
+  "pub_key":    "ed25519:<hex>",
+  "salt":       "<hex 16 bytes>",
+  "nonce":      "<hex 12 bytes>",
+  "ciphertext": "<hex — AES-256-GCM of the 64-byte ed25519.PrivateKey>"
+}
+```
+
+| Parameter | Value |
+|-----------|-------|
+| PBKDF2 algorithm  | `PBKDF2-HMAC-SHA256` (`golang.org/x/crypto/pbkdf2`) |
+| PBKDF2 iterations | 600 000 |
+| Derived key       | 32 bytes (256-bit) |
+| Salt              | 16 bytes (random, `crypto/rand`) |
+| Nonce             | 12 bytes (random, `crypto/rand`) |
+| Cipher            | `AES-256-GCM` (`crypto/aes` + `crypto/cipher`) |
+| Plaintext         | Raw `ed25519.PrivateKey` bytes (64 B: seed \|\| public key) |
+
+`Load` recomputes the PBKDF2 key and decrypts; a wrong passphrase surfaces
+as `*core.ErrIdentity{Msg: "decryption failed — wrong passphrase?"}`.
+
+> **Cross-SDK note.** The Go envelope stores the full 64-byte Go-stdlib
+> `ed25519.PrivateKey`. The Rust envelope stores the 32-byte seed; the
+> Java envelope stores PKCS#8 / X.509 DER. The three formats are **not**
+> interchangeable byte-for-byte — use `PubKeyString()` + `Sign` output
+> for cross-SDK interop instead of loading another SDK's key file.
+
+---
+
+## End-to-end
+
+```go
+import (
+    "github.com/labacacia/nps/impl/go/core"
+    "github.com/labacacia/nps/impl/go/nip"
+)
+
+id, err := nip.Generate()
+if err != nil { /* … */ }
+nid := "urn:nps:node:api.example.com:products"
+
+// Sign a payload
+payload := core.FrameDict{
+    "action": "announce",
+    "nid":    nid,
+}
+sig := id.Sign(payload)
+ok  := id.Verify(payload, sig)
+_ = ok // true
+
+// Cross-key verification (e.g. via NDP announce validator)
+ok = nip.VerifyWithPubKeyStr(payload, id.PubKeyString(), sig)
+
+// Encrypted persistence
+if err := id.Save("node.key", "my-passphrase"); err != nil { /* … */ }
+loaded, err := nip.Load("node.key", "my-passphrase")
+if err != nil { /* … */ }
+_ = loaded.PubKeyString() == id.PubKeyString()   // true
+```

--- a/doc/nps-go.nop.md
+++ b/doc/nps-go.nop.md
@@ -1,0 +1,313 @@
+# `github.com/labacacia/nps/impl/go/nop` — Reference
+
+> Spec: [NPS-5 NOP v0.3](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-5-NOP.md)
+
+Orchestration layer — DAG submission, fan-in barriers, streaming
+progress, async status polling.
+
+---
+
+## Table of contents
+
+- [`BackoffStrategy`](#backoffstrategy)
+- [`TaskState`](#taskstate)
+- [`NopTaskStatus`](#noptaskstatus)
+- [`TaskFrame` (0x40)](#taskframe-0x40)
+- [`DelegateFrame` (0x41)](#delegateframe-0x41)
+- [`SyncFrame` (0x42)](#syncframe-0x42)
+- [`AlignStreamFrame` (0x43)](#alignstreamframe-0x43)
+- [`NopClient`](#nopclient)
+
+---
+
+## `BackoffStrategy`
+
+```go
+type BackoffStrategy int
+
+const (
+    BackoffFixed BackoffStrategy = iota
+    BackoffLinear
+    BackoffExponential
+)
+
+// Package-level function — not a method.
+func ComputeDelayMs(strategy BackoffStrategy, baseMs, maxMs int64, attempt int) int64
+```
+
+`ComputeDelayMs` (0-indexed `attempt`):
+
+| Strategy             | Formula                     |
+|----------------------|-----------------------------|
+| `BackoffFixed`       | `baseMs`                    |
+| `BackoffLinear`      | `baseMs * (attempt + 1)`    |
+| `BackoffExponential` | `baseMs << attempt` (≡ `baseMs * 2^attempt`) |
+
+Result is clamped at `maxMs`.
+
+---
+
+## `TaskState`
+
+```go
+type TaskState string
+
+const (
+    TaskStatePending   TaskState = "pending"
+    TaskStateRunning   TaskState = "running"
+    TaskStateCompleted TaskState = "completed"
+    TaskStateFailed    TaskState = "failed"
+    TaskStateCancelled TaskState = "cancelled"
+)
+
+func TaskStateFromString(s string) (TaskState, error)   // errors on unknown
+func (s TaskState) IsTerminal() bool                    // Completed | Failed | Cancelled
+```
+
+> The Go SDK exposes only the five common states above. Orchestrator
+> responses carrying `"preflight"`, `"waiting_sync"` or `"skipped"` will
+> still decode via `NopTaskStatus.State()` but the returned `TaskState`
+> value will not match any of the declared constants. Use
+> `NopTaskStatus.String()` / the raw payload to inspect the original
+> string when needed.
+
+---
+
+## `NopTaskStatus`
+
+Thin view over the orchestrator's JSON status payload.
+
+```go
+type NopTaskStatus struct { /* raw map[string]any */ }
+
+func NewNopTaskStatus(raw map[string]any) *NopTaskStatus
+
+func (s *NopTaskStatus) TaskID()       string
+func (s *NopTaskStatus) State()        TaskState
+func (s *NopTaskStatus) IsTerminal()   bool
+func (s *NopTaskStatus) ErrorCode()    string
+func (s *NopTaskStatus) ErrorMessage() string
+func (s *NopTaskStatus) NodeResults()  map[string]any
+func (s *NopTaskStatus) String()       string             // "NopTaskStatus(task_id=…, state=…)"
+```
+
+The internal `raw` map is not exposed — accessors return zero-values
+(`""`, `nil`) when the underlying field is missing or mis-typed.
+
+---
+
+## `TaskFrame` (0x40)
+
+Submit a DAG for execution. The DAG itself is kept as a free-form `any`
+value that matches the NPS-5 wire shape (`{"nodes": [...], "edges": [...]}`).
+
+```go
+type TaskFrame struct {
+    TaskID      string
+    DAG         any                  // free-form DAG JSON
+    TimeoutMs   *uint64
+    CallbackURL *string               // SSRF-validated by orchestrator
+    Context     any                   // { "session_key", "requester_nid", "trace_id" }
+    Priority    *string               // "low" | "normal" | "high"
+    Depth       *int64                // delegate chain depth, max 3
+}
+```
+
+Spec limits the orchestrator enforces (NPS-5 §8.2): max 32 nodes per DAG,
+max 3 levels of delegate chain, max timeout 3 600 000 ms (1 h).
+
+---
+
+## `DelegateFrame` (0x41)
+
+Per-node invocation emitted by the orchestrator to each agent.
+
+```go
+type DelegateFrame struct {
+    TaskID         string
+    SubtaskID      string
+    Action         string
+    TargetNID      string
+    Inputs         any
+    Config         any
+    IdempotencyKey *string
+}
+```
+
+> Field naming differs from other SDKs: the Go SDK uses `TargetNID` +
+> `Config` where the .NET / Python / Java SDKs use `agent_nid` +
+> `params`. Wire payloads follow the field names above (`target_nid` /
+> `config`).
+
+---
+
+## `SyncFrame` (0x42)
+
+Fan-in barrier — waits for K-of-N upstream subtasks.
+
+```go
+type SyncFrame struct {
+    TaskID      string
+    SyncID      string
+    SubtaskIDs  []string
+    MinRequired int64               // 0 = strict all-of
+    Aggregate   string              // "merge" | "first" | "fastest_k" | "all"
+    TimeoutMs   *uint64
+}
+```
+
+`SyncFrameFromDict` defaults `Aggregate` to `"merge"` when the field is
+missing.
+
+`MinRequired` semantics:
+
+| Value | Meaning |
+|-------|---------|
+| `0`   | Wait for all of `SubtaskIDs` (strict fan-in). |
+| `K`   | Proceed as soon as K upstream subtasks have completed. |
+
+---
+
+## `AlignStreamFrame` (0x43)
+
+Streaming progress / partial result frame for a delegated subtask.
+
+```go
+type AlignStreamFrame struct {
+    SyncID     string
+    TaskID     string
+    SubtaskID  string
+    Seq        uint64
+    IsFinal    bool
+    SourceNID  *string
+    Result     any                  // opaque payload
+    Error      map[string]any       // { "error_code", "message" }
+    WindowSize *uint64
+}
+
+func (f *AlignStreamFrame) ErrorCode()    string   // shortcut for Error["error_code"]
+func (f *AlignStreamFrame) ErrorMessage() string   // shortcut for Error["message"]
+```
+
+`AlignStreamFrame` replaces the deprecated `AlignFrame (0x05)` — it
+carries task context (`TaskID` + `SubtaskID` + `SyncID`) and binds the
+stream to a `SourceNID`.
+
+---
+
+## `NopClient`
+
+HTTP-mode NOP client.
+
+```go
+type NopClient struct { /* … */ }
+
+func NewNopClient    (baseURL string)                              *NopClient
+func NewNopClientFull(baseURL string, httpClient *http.Client)    *NopClient
+
+func (c *NopClient) Submit   (ctx context.Context, frame *TaskFrame)  (string, error)          // → task_id
+func (c *NopClient) GetStatus(ctx context.Context, taskID string)     (*NopTaskStatus, error)
+func (c *NopClient) Cancel   (ctx context.Context, taskID string)      error
+
+func (c *NopClient) Wait(
+    ctx     context.Context,
+    taskID  string,
+    opts    *WaitOptions,      // pass nil for defaults
+) (*NopTaskStatus, error)
+
+type WaitOptions struct {
+    PollInterval time.Duration   // default 500ms
+    MaxAttempts  int             // 0 = unlimited (rely on ctx for timeout)
+}
+```
+
+### HTTP routes
+
+| Method       | Method | Path                      | Request body                   | Response |
+|--------------|--------|---------------------------|--------------------------------|----------|
+| `Submit`     | POST   | `/tasks`                  | JSON of `TaskFrame.ToDict()`   | JSON `{ "task_id": … }` |
+| `GetStatus`  | GET    | `/tasks/{id}`             | —                              | JSON status dict |
+| `Cancel`     | POST   | `/tasks/{id}/cancel`      | `{"task_id","action":"cancel"}`| — |
+| `Wait`       | polls `GetStatus` until terminal / ctx cancelled / `MaxAttempts` exceeded; `time.After(PollInterval)` between polls |
+
+> `Cancel` uses `POST /tasks/{id}/cancel` — this differs from the Rust
+> SDK which uses `DELETE /tasks/{id}`. The route is encoded in the Go
+> client and is not configurable.
+
+Requests use `Content-Type: application/json` — the NOP client submits
+the task dict as plain JSON, not as a framed `application/x-nps-frame`
+payload.
+
+`Wait` returns `ctx.Err()` if the context is cancelled; returns the
+terminal `*NopTaskStatus` on success; returns the most recent non-terminal
+status plus an error like `"NOP Wait: exceeded N poll attempts …"` when
+`opts.MaxAttempts > 0` is reached.
+
+### Errors
+
+- Non-2xx HTTP → `fmt.Errorf("NOP %s failed: HTTP %d", op, status)` where
+  `op` is `"Submit"` / `"GetStatus"` / `"Cancel"`.
+- If `Submit` gets a 2xx response with no `task_id` in the body, the
+  client falls back to returning `frame.TaskID`.
+- Transport failures surface from `http.Client.Do` / `json.Decoder`.
+
+---
+
+## End-to-end
+
+```go
+import (
+    "context"
+    "time"
+    "github.com/labacacia/nps/impl/go/nop"
+)
+
+dag := map[string]any{
+    "nodes": []any{
+        map[string]any{
+            "id":     "fetch",
+            "action": "fetch",
+            "agent":  "urn:nps:node:ingest.example.com:http",
+        },
+        map[string]any{
+            "id":         "classify",
+            "action":     "classify",
+            "agent":      "urn:nps:node:ml.example.com:classifier",
+            "input_from": []any{"fetch"},
+            "retry_policy": map[string]any{
+                "max_retries":   3,
+                "backoff":       "exponential",
+                "base_delay_ms": 500,
+            },
+        },
+    },
+    "edges": []any{
+        map[string]any{"from": "fetch", "to": "classify"},
+    },
+}
+
+timeoutMs := uint64(60_000)
+priority  := "normal"
+
+client := nop.NewNopClient("http://orchestrator.example.com:17433")
+ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+defer cancel()
+
+tid, err := client.Submit(ctx, &nop.TaskFrame{
+    TaskID:    "job-42",
+    DAG:       dag,
+    TimeoutMs: &timeoutMs,
+    Priority:  &priority,
+})
+if err != nil { /* … */ }
+
+status, err := client.Wait(ctx, tid, &nop.WaitOptions{
+    PollInterval: 500 * time.Millisecond,
+})
+if err != nil { /* … */ }
+_ = status.String()
+
+// Backoff computation
+delay := nop.ComputeDelayMs(nop.BackoffExponential, 500, 30_000, 2)  // → 2000
+_ = delay
+```

--- a/doc/nps-go.nwp.md
+++ b/doc/nps-go.nwp.md
@@ -1,0 +1,207 @@
+# `github.com/labacacia/nps/impl/go/nwp` — Reference
+
+> Spec: [NPS-2 NWP v0.4](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-2-NWP.md)
+
+Agent-facing HTTP layer. Two frame types + a `net/http`-based client.
+
+---
+
+## Table of contents
+
+- [`QueryFrame` (0x10)](#queryframe-0x10)
+- [`ActionFrame` (0x11)](#actionframe-0x11)
+- [`AsyncActionResponse`](#asyncactionresponse)
+- [`NwpClient`](#nwpclient)
+- [`InvokeResult`](#invokeresult)
+
+---
+
+## `QueryFrame` (0x10)
+
+Paginated / filtered query against a Memory Node.
+
+```go
+type QueryFrame struct {
+    AnchorRef   string        // required
+    Filter      any           // NPS-2 §4 filter DSL (free-form)
+    Order       any           // e.g. [{"field":"id","dir":"asc"}]
+    TokenBudget *uint64       // NPT Budget cap (NPS Token Budget spec)
+    Limit       *uint64
+    Offset      *uint64
+}
+```
+
+`AnchorRef` is non-optional. The Go `QueryFrame` does not carry the
+`vector_search` / `fields` / `depth` fields of the Java / Python / TS SDKs
+— use `Filter` / `Order` for the equivalent logic and advertise the
+vector-search dialect in the anchor schema.
+
+Pointer fields (`*uint64`) encode "absent" as `nil`. Only set the pointer
+when the caller wants the field on the wire.
+
+---
+
+## `ActionFrame` (0x11)
+
+Invoke an action on a node.
+
+```go
+type ActionFrame struct {
+    Action    string
+    Params    any
+    AnchorRef *string
+    Async     bool             // serialises to "async" on the wire
+}
+```
+
+`IdempotencyKey` / `TimeoutMs` are not modelled as struct fields — attach
+them via `Params` if the remote action supports them.
+
+---
+
+## `AsyncActionResponse`
+
+Returned by `NwpClient.Invoke` when the request frame has `Async == true`
+(surfaced via `InvokeResult.Async`).
+
+```go
+type AsyncActionResponse struct {
+    TaskID      string
+    StatusURL   *string
+    CallbackURL *string
+}
+
+func AsyncActionResponseFromDict(d core.FrameDict) *AsyncActionResponse
+```
+
+Poll `StatusURL` or hand `TaskID` to
+[`NopClient.Wait`](./nps-go.nop.md#nopclient) to reach a terminal state.
+
+---
+
+## `NwpClient`
+
+HTTP-mode NWP client.
+
+```go
+type NwpClient struct { /* … */ }
+
+func NewNwpClient(baseURL string) *NwpClient
+
+func NewNwpClientFull(
+    baseURL    string,
+    tier       core.EncodingTier,
+    reg        *core.FrameRegistry,
+    httpClient *http.Client,     // pass nil to use http.DefaultClient
+) *NwpClient
+
+func (c *NwpClient) SendAnchor(ctx context.Context, f *ncp.AnchorFrame) error
+func (c *NwpClient) Query     (ctx context.Context, f *QueryFrame)    (*ncp.CapsFrame, error)
+func (c *NwpClient) Stream    (ctx context.Context, f *QueryFrame)    ([]*ncp.StreamFrame, error)
+func (c *NwpClient) Invoke    (ctx context.Context, f *ActionFrame)   (*InvokeResult, error)
+```
+
+### Defaults
+
+- Trailing `/` is stripped from `baseURL`; every call POSTs to
+  `{baseURL}/{route}`.
+- `NewNwpClient` uses `core.EncodingTierMsgPack` and
+  `core.CreateFullRegistry()` — queries and actions can reach nodes that
+  respond with NCP, NIP, NDP or NOP frames.
+- `NewNwpClientFull` exposes tier / registry / HTTP-client overrides. Pass
+  `nil` for `httpClient` to fall back to `http.DefaultClient`.
+- Every method takes a `context.Context` — cancellation / deadlines
+  propagate to the underlying `http.Request`.
+
+### HTTP routes
+
+| Method       | Path      | Request body                 | Response body |
+|--------------|-----------|------------------------------|---------------|
+| `SendAnchor` | `/anchor` | encoded `AnchorFrame`        | — (2xx only) |
+| `Query`      | `/query`  | encoded `QueryFrame`         | encoded `CapsFrame` |
+| `Stream`     | `/stream` | encoded `QueryFrame`         | concatenated `StreamFrame`s |
+| `Invoke`     | `/invoke` | encoded `ActionFrame`        | encoded frame, JSON (async), or fallback JSON |
+
+Request headers: `Content-Type: application/x-nps-frame`,
+`Accept: application/x-nps-frame`.
+
+### `Stream` behaviour
+
+Buffered: the response body is read into a `[]byte`, then sliced
+frame-by-frame via `core.ParseFrameHeader`. Iteration stops when a frame
+reports `IsLast == true` (the in-payload flag — not the wire FINAL bit).
+
+### `Invoke` dispatch
+
+| Request | Response Content-Type | Returned field |
+|---------|-----------------------|----------------|
+| `Async == true`  | any                                  | `InvokeResult{Async: …}`           |
+| `Async == false` | contains `application/x-nps-frame`   | `InvokeResult{Frame: &dict}`       |
+| `Async == false` | anything else                        | `InvokeResult{JSON: map[string]any}` |
+
+### Errors
+
+- Non-2xx HTTP → `fmt.Errorf("NWP /{path} failed: HTTP {status}")`.
+- Transport failure → returned verbatim from `http.Client.Do`.
+- Payload decode failure → `*core.ErrCodec` (via `codec.Decode`).
+- Unexpected frame type (e.g. `Query` returns non-Caps) →
+  `fmt.Errorf("expected CapsFrame, got 0x%02X", ft)`.
+
+---
+
+## `InvokeResult`
+
+```go
+type InvokeResult struct {
+    Frame *core.FrameDict          // NPS-encoded response (already decoded to dict)
+    Async *AsyncActionResponse     // 202-style async handle
+    JSON  map[string]any           // JSON response (non-NPS content-type)
+}
+```
+
+Exactly one of the three fields is non-nil per result. Unlike the Rust
+SDK's `InvokeResult` enum, the Go type is a plain struct — inspect the
+fields directly rather than pattern-matching. If you need a typed NCP
+frame from `Frame`, call the relevant `XxxFrameFromDict(*r.Frame)`.
+
+---
+
+## End-to-end
+
+```go
+import (
+    "context"
+    "github.com/labacacia/nps/impl/go/nwp"
+    "github.com/labacacia/nps/impl/go/ncp"
+)
+
+client := nwp.NewNwpClient("http://node.example.com:17433")
+ctx    := context.Background()
+
+// Query
+limit := uint64(50)
+caps, err := client.Query(ctx, &nwp.QueryFrame{
+    AnchorRef: "sha256:abc123",
+    Filter:    map[string]any{"active": true},
+    Limit:     &limit,
+})
+if err != nil { /* … */ }
+_ = caps.Caps
+
+// Invoke
+result, err := client.Invoke(ctx, &nwp.ActionFrame{
+    Action: "summarise",
+    Params: map[string]any{"max_tokens": 500},
+    Async:  false,
+})
+if err != nil { /* … */ }
+switch {
+case result.Frame != nil:
+    back := ncp.CapsFrameFromDict(*result.Frame)
+    _ = back
+case result.Async != nil:
+    _ = result.Async.TaskID
+case result.JSON != nil:
+    _ = result.JSON
+}
+```

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,146 @@
+# NPS Go SDK — API Reference
+
+> Go client library for the Neural Protocol Suite. Module path:
+> `github.com/labacacia/nps/impl/go`, Go 1.23+ (recommended 1.25+).
+
+This directory is the package-and-function reference for the Go SDK.
+For a narrative walkthrough see [`sdk-usage.md`](./sdk-usage.md)
+(English) / [`sdk-usage.cn.md`](./sdk-usage.cn.md) (中文).
+
+---
+
+## Packages
+
+| Import suffix | Purpose | Reference |
+|---------------|---------|-----------|
+| `/core` | Frame header, codec (Tier-1 JSON / Tier-2 MsgPack), registry, anchor cache, errors | [`nps-go.core.md`](./nps-go.core.md) |
+| `/ncp`  | NCP frames — `AnchorFrame`, `DiffFrame`, `StreamFrame`, `CapsFrame`, `ErrorFrame` | [`nps-go.ncp.md`](./nps-go.ncp.md) |
+| `/nwp`  | NWP frames + HTTP `NwpClient` | [`nps-go.nwp.md`](./nps-go.nwp.md) |
+| `/nip`  | NIP frames + `NipIdentity` (Ed25519, AES-256-GCM key store) | [`nps-go.nip.md`](./nps-go.nip.md) |
+| `/ndp`  | NDP frames + `InMemoryNdpRegistry` + `NdpAnnounceValidator` | [`nps-go.ndp.md`](./nps-go.ndp.md) |
+| `/nop`  | NOP frames + `BackoffStrategy` + `NopTaskStatus` + `NopClient` | [`nps-go.nop.md`](./nps-go.nop.md) |
+
+Module root is `github.com/labacacia/nps/impl/go`; every package above is
+imported as `"github.com/labacacia/nps/impl/go/{core,ncp,nwp,nip,ndp,nop}"`.
+
+---
+
+## Install
+
+```bash
+go get github.com/labacacia/nps/impl/go@v1.0.0-alpha.1
+```
+
+Runtime dependencies (resolved by `go mod tidy`):
+
+- `github.com/vmihailenco/msgpack/v5` — MsgPack codec
+- `golang.org/x/crypto/pbkdf2` — key derivation for `NipIdentity`
+- `crypto/ed25519`, `crypto/aes`, `crypto/cipher` — stdlib
+
+---
+
+## Minimal encode / decode
+
+```go
+import (
+    "github.com/labacacia/nps/impl/go/core"
+    "github.com/labacacia/nps/impl/go/ncp"
+)
+
+codec := core.NewNpsFrameCodec(core.CreateFullRegistry())
+
+schema := core.FrameDict{
+    "fields": []any{
+        map[string]any{"name": "id",    "type": "uint64"},
+        map[string]any{"name": "price", "type": "decimal"},
+    },
+}
+anchorID := core.ComputeAnchorID(schema)
+frame := &ncp.AnchorFrame{AnchorID: anchorID, Schema: schema, TTL: 3600}
+
+wire, err := codec.Encode(
+    frame.FrameType(),
+    frame.ToDict(),
+    core.EncodingTierMsgPack,
+    true, // isFinal
+)
+if err != nil { /* … */ }
+
+ft, dict, err := codec.Decode(wire)
+if err != nil { /* … */ }
+if ft == core.FrameTypeAnchor {
+    back := ncp.AnchorFrameFromDict(dict)
+    _ = back
+}
+```
+
+The codec is dict-oriented: each frame struct exposes
+`FrameType() core.FrameType` + `ToDict() core.FrameDict`, and each
+package ships a `{Frame}FromDict(core.FrameDict) *{Frame}` constructor.
+Call these explicitly around `codec.Encode` / `codec.Decode`.
+
+---
+
+## Encoding tiers
+
+| Tier | Constant | Wire flag (bit 7) | Notes |
+|------|----------|-------------------|-------|
+| Tier-1 JSON    | `core.EncodingTierJSON`    | `0` | UTF-8 JSON, debug / interop |
+| Tier-2 MsgPack | `core.EncodingTierMsgPack` | `1` | `msgpack/v5`, production default |
+
+**Flag byte layout** (matches the Rust SDK; differs from Java / Python / TS):
+
+| Bit | Mask   | Meaning |
+|-----|--------|---------|
+| 7   | `0x80` | TIER — `1` = MsgPack, `0` = JSON |
+| 6   | `0x40` | FINAL — last frame in a stream |
+| 0   | `0x01` | EXT — 8-byte extended header (payload > 65 535 bytes) |
+
+Header sizes: 4 bytes default, 8 bytes when `EXT = 1`
+(`[type][flags][0][0][len_b3..len_b0]`). Max payload defaults to 10 MiB
+(`core.DefaultMaxPayload`) — raise by setting `codec.MaxPayload` after
+construction.
+
+---
+
+## HTTP clients
+
+- `NwpClient` (`/nwp`) uses `net/http`, `Content-Type: application/x-nps-frame`.
+- `NopClient` (`/nop`) uses `net/http`, `Content-Type: application/json`
+  (tasks are submitted as plain JSON dicts, not framed NPS payloads).
+- Both constructors accept an optional `*http.Client`; pass `nil` to
+  use `http.DefaultClient`.
+- Every public method takes a `context.Context` — cancellation /
+  deadlines propagate through to the underlying HTTP request.
+
+---
+
+## Errors
+
+`core/errors.go` defines pointer error types — use
+`errors.As` to unwrap:
+
+| Type | Raised by |
+|------|-----------|
+| `*core.ErrFrame`          | Unknown / unregistered frame types, missing fields |
+| `*core.ErrCodec`          | JSON / MsgPack encode / decode failure, payload oversized |
+| `*core.ErrAnchorNotFound` | `AnchorFrameCache.GetRequired` on missing / expired anchor |
+| `*core.ErrAnchorPoison`   | `AnchorFrameCache.Set` with schema mismatch for same `anchor_id` |
+| `*core.ErrIdentity`       | Key gen / save / load / PBKDF2 / AES-GCM failure |
+
+Non-2xx HTTP responses surface as `fmt.Errorf` with the pattern
+`"NWP /{path} failed: HTTP {status}"` or
+`"NOP {op} failed: HTTP {status}"`.
+
+---
+
+## Spec links
+
+- [NPS-0 Overview](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-0-Overview.md)
+- [NPS-1 NCP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-1-NCP.md)
+- [NPS-2 NWP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-2-NWP.md)
+- [NPS-3 NIP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-3-NIP.md)
+- [NPS-4 NDP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-4-NDP.md)
+- [NPS-5 NOP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-5-NOP.md)
+- [Frame registry](https://github.com/labacacia/NPS-Release/blob/main/spec/frame-registry.yaml)
+- [Error codes](https://github.com/labacacia/NPS-Release/blob/main/spec/error-codes.md)


### PR DESCRIPTION
## Summary

- Adds `doc/overview.md` + one reference per package (`core`, `ncp`, `nwp`, `nip`, `ndp`, `nop`) matching the structure already shipped for the .NET / Python / TypeScript / Java / Rust SDKs.
- Documents Go-specific details that diverge from the other SDKs: pointer-optional fields, `FrameDict` type alias, `sync.RWMutex`-backed caches / registries, `context.Context` propagation, `WaitOptions` polling struct, `errors.As` with pointer error types.
- Captures the Go-specific NCP frame shapes (`AnchorFrame` extras, `DiffFrame` anchor_id/new_anchor_id, `StreamFrame` anchor_id/seq/payload/is_last, `CapsFrame` envelope, `ErrorFrame` error_code/message/detail) and NOP frame field names (`TargetNID`/`Config`, `SubtaskIDs`, `SyncID`/`SourceNID`/`Result`).
- README `Packages` table gains a `Reference` column + a pointer to `doc/overview.md`. Existing `sdk-usage.md` / `sdk-usage.cn.md` are preserved.

## Test plan

- [x] Reviewed every new `doc/*.md` against the actual `core/`, `ncp/`, `nwp/`, `nip/`, `ndp/`, `nop/` source to make sure the signatures and behaviours described match the code.
- [x] `README.md` table links resolve to the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)